### PR TITLE
RPRUN-215 Max ray depth parameter doesn't work (#88)

### DIFF
--- a/Plugins/RPRPlugin/Source/RPRCore/Private/RPRCoreSystemResources.cpp
+++ b/Plugins/RPRPlugin/Source/RPRCore/Private/RPRCoreSystemResources.cpp
@@ -294,7 +294,7 @@ bool FRPRCoreSystemResources::InitializeContextParameters()
 	{
 	case Tahoe:
 		ContextSetUint(RPRContext, RPR_CONTEXT_PREVIEW, 1, TEXT("PREVIEW"));
-		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_RECURSION, 10, TEXT("MAX_RECURSION"));
+		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_RECURSION, settings->RayDepthMax, TEXT("MAX_RECURSION"));
 		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_DEPTH_DIFFUSE, settings->RayDepthDiffuse, TEXT("MAX_DEPTH_DIFFUSE"));
 		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_DEPTH_GLOSSY, settings->RayDepthGlossy, TEXT("MAX_DEPTH_GLOSSY"));
 		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_DEPTH_SHADOW, settings->RayDepthShadow, TEXT("MAX_DEPTH_SHADOW"));
@@ -306,7 +306,7 @@ bool FRPRCoreSystemResources::InitializeContextParameters()
 		ContextSetUint(RPRContext, RPR_CONTEXT_ADAPTIVE_SAMPLING_MIN_SPP, settings->SamplingMin, TEXT("ADAPTIVE_SAMPLING_MIN_SPP"));
 		break;
 	case Hybrid:
-		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_RECURSION, 10, TEXT("MAX_RECURSION"));
+		ContextSetUint(RPRContext, RPR_CONTEXT_MAX_RECURSION, settings->RayDepthMax, TEXT("MAX_RECURSION"));
 		ContextSetUint(RPRContext, RPR_CONTEXT_Y_FLIP, 1, TEXT("Y_FLIP"));
 		break;
 	default:

--- a/Plugins/RPRPlugin/Source/RPRTools/Public/RPRSettings.h
+++ b/Plugins/RPRPlugin/Source/RPRTools/Public/RPRSettings.h
@@ -137,16 +137,16 @@ public:
 	UPROPERTY(Config)
 	float		PhotolinearTonemapFStop;
 
-	UPROPERTY(Config, EditAnywhere, Category = RenderSettings)
+	UPROPERTY(Config)
 	float		RaycastEpsilon;
 
-	UPROPERTY(Config, EditAnywhere, Category = RenderSettings)
+	UPROPERTY(Config)
 	uint32		SamplingMax;
 
-	UPROPERTY(Config, EditAnywhere, Category = RenderSettings)
+	UPROPERTY(Config)
 	uint32		SamplingMin;
 
-	UPROPERTY(Config, EditAnywhere, Category = RenderSettings)
+	UPROPERTY(Config)
 	float		NoiseThreshold;
 
 	UPROPERTY(Config, EditAnywhere, Category = RenderSettings)


### PR DESCRIPTION
PURPOSE
Use Ray Depth property in a context.
Remove duplicated properties from settings.

EFFECT OF CHANGE
Changing of ray depth will work in the plugin