### PR TITLE
Viewport crash

### DIFF
--- a/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.cpp
+++ b/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.cpp
@@ -66,6 +66,7 @@ FRPRRendererWorker::FRPRRendererWorker(rpr_context context, rpr_scene rprScene, 
 ,	m_RprContext(context)
 ,	m_AOV(RPR::EAOV::Color)
 ,	m_RprScene(rprScene)
+,	m_ExpectedRenderDataSize(0)
 ,	m_Resize(true)
 ,	m_IsBuildingObjects(false)
 ,	m_ClearFramebuffer(false)
@@ -180,11 +181,12 @@ bool	FRPRRendererWorker::ResizeFramebuffer(uint32 width, uint32 height)
 		return false;
 
 	m_PreRenderLock.Lock();
+
 	m_Width = width;
 	m_Height = height;
 
 	m_Resize = true;
-	m_RenderData.SetNumZeroed(m_Width * m_Height * sizeof(float));
+	m_ExpectedRenderDataSize = m_Width * m_Height * sizeof(float) * (sizeof(float) / sizeof(uint8));
 
 	m_PreRenderLock.Unlock();
 	return true;
@@ -398,7 +400,7 @@ bool	FRPRRendererWorker::BuildFramebufferData()
 		UE_LOG(LogRPRRenderer, Error, TEXT("Couldn't get framebuffer infos"));
 		return false;
 	}
-	if (m_SrcFramebufferData.Num() != totalByteCount / sizeof(float) ||
+	if (m_SrcFramebufferData.Num() != (totalByteCount / sizeof(float)) ||
 		m_DstFramebufferData.Num() != totalByteCount ||
 		m_RenderData.Num() != totalByteCount)
 	{
@@ -478,9 +480,11 @@ int FRPRRendererWorker::ResizeFramebuffer()
 	m_RprFrameBufferDesc.fb_width = m_Width;
 	m_RprFrameBufferDesc.fb_height = m_Height;
 
-	m_SrcFramebufferData.SetNum(m_Width * m_Height * 4);
-	m_DstFramebufferData.SetNum(m_Width * m_Height * 16);
-	m_RenderData.SetNum(m_DstFramebufferData.Num());
+	const uint32 floatBufSize = m_Width * m_Height * sizeof(float);
+	const uint32 uint8BufSize = floatBufSize * sizeof(float) / sizeof(uint8);
+	m_SrcFramebufferData.SetNum(floatBufSize);
+	m_DstFramebufferData.SetNum(uint8BufSize);
+	m_RenderData.SetNum(uint8BufSize);
 
 	if (ContextCreateFrameBuffer(m_RprContext, m_RprFrameBufferFormat, &m_RprFrameBufferDesc, &m_RprFrameBuffer)                    != RPR_SUCCESS ||
 		ContextCreateFrameBuffer(m_RprContext, m_RprFrameBufferFormat, &m_RprFrameBufferDesc, &m_RprResolvedFrameBuffer)            != RPR_SUCCESS ||
@@ -766,7 +770,8 @@ bool	FRPRRendererWorker::PreRenderLoop()
 
 	if (!settings->IsHybrid)
 	{
-		if (!isPaused || m_CurrentIteration < settings->MaximumRenderIterations)
+		// For Tahoe use SamplingMax as iterations limit
+		if (!isPaused || m_CurrentIteration < settings->SamplingMax)
 		{
 			// Settings expose raycast epsilon in millimeters
 			const float	raycastEpsilon = settings->RaycastEpsilon / 1000.0f;

--- a/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.cpp
+++ b/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.cpp
@@ -66,7 +66,6 @@ FRPRRendererWorker::FRPRRendererWorker(rpr_context context, rpr_scene rprScene, 
 ,	m_RprContext(context)
 ,	m_AOV(RPR::EAOV::Color)
 ,	m_RprScene(rprScene)
-,	m_ExpectedRenderDataSize(0)
 ,	m_Resize(true)
 ,	m_IsBuildingObjects(false)
 ,	m_ClearFramebuffer(false)
@@ -78,6 +77,7 @@ FRPRRendererWorker::FRPRRendererWorker(rpr_context context, rpr_scene rprScene, 
 {
 	m_Plugin = &FRPRPluginModule::Get();
 	m_Thread = FRunnableThread::Create(this, TEXT("FRPRRendererWorker"));
+	m_ExpectedRenderDataSize = m_Width * m_Height * sizeof(float) * (sizeof(float) / sizeof(uint8));
 }
 
 FRPRRendererWorker::~FRPRRendererWorker()

--- a/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.h
+++ b/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.h
@@ -64,6 +64,11 @@ public:
 		return m_RenderData.GetData();
 	}
 
+	const bool		IsRenderDataCorrect()
+	{
+		return m_ExpectedRenderDataSize == m_RenderData.Num();
+	}
+
 public:
 
 	FCriticalSection	m_DataLock;
@@ -147,6 +152,7 @@ private:
 	TArray<uint8>				m_DstFramebufferData;
 	TArray<uint8>				m_RenderData;
 
+	size_t						m_ExpectedRenderDataSize;
 	bool						m_Resize;
 	bool						m_IsBuildingObjects;
 	bool						m_ClearFramebuffer;

--- a/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.h
+++ b/Plugins/RPRPlugin/Source/RPRPlugin/Private/Renderer/RPRRendererWorker.h
@@ -64,7 +64,7 @@ public:
 		return m_RenderData.GetData();
 	}
 
-	const bool		IsRenderDataCorrect()
+	bool			IsRenderDataCorrect()
 	{
 		return m_ExpectedRenderDataSize == m_RenderData.Num();
 	}
@@ -152,7 +152,7 @@ private:
 	TArray<uint8>				m_DstFramebufferData;
 	TArray<uint8>				m_RenderData;
 
-	size_t						m_ExpectedRenderDataSize;
+	uint32						m_ExpectedRenderDataSize;
 	bool						m_Resize;
 	bool						m_IsBuildingObjects;
 	bool						m_ClearFramebuffer;

--- a/Plugins/RPRPlugin/Source/RPRPlugin/Private/Scene/RPRScene.cpp
+++ b/Plugins/RPRPlugin/Source/RPRPlugin/Private/Scene/RPRScene.cpp
@@ -754,10 +754,14 @@ void ARPRScene::CopyRPRRenderBufferToViewportRenderTexture()
 
 	m_RendererWorker->m_DataLock.Lock();
 	const uint8	*textureData = m_RendererWorker->GetFramebufferData();
+	const bool	update = m_RendererWorker->IsRenderDataCorrect();
 #if  ENGINE_MINOR_VERSION >= 24
 	ENQUEUE_RENDER_COMMAND(UpdateDynamicTextureCode) (
-		[this, textureData](FRHICommandListImmediate& RHICmdList)
+		[this, textureData, update](FRHICommandListImmediate& RHICmdList)
 		{
+			if (!update)
+				return;
+
 			FUpdateTextureRegion2D	region;
 			region.SrcX   = 0;
 			region.SrcY   = 0;


### PR DESCRIPTION
PURPOSE
Improve stability

EFFECT OF CHANGE
Resolve crash when mismatch sizes of the viewport and render data

TECHNICAL STEPS
Do not update RHI texture while RPR data not ready yet